### PR TITLE
Add XWAYLAND_NO_GLAMOR=1 to wlroots env vars

### DIFF
--- a/wlroots-env-nvidia.sh
+++ b/wlroots-env-nvidia.sh
@@ -4,7 +4,7 @@
 
 # Hardware cursors not yet working on wlroots
 export WLR_NO_HARDWARE_CURSORS=1
-# Set WLRoots renderer to Vulkan to avoid flickering
+# Set wlroots renderer to Vulkan to avoid flickering
 export WLR_RENDERER=vulkan
 # General wayland environment variables
 export XDG_SESSION_TYPE=wayland
@@ -18,3 +18,5 @@ export GBM_BACKEND=nvidia-drm
 export __GL_GSYNC_ALLOWED=0
 export __GL_VRR_ALLOWED=0
 export __GLX_VENDOR_LIBRARY_NAME=nvidia
+# Xwayland compatibility
+export XWAYLAND_NO_GLAMOR=1


### PR DESCRIPTION
This is literally the only way I've been able to get Xwayland apps to work- after almost a full year of just avoiding the problem, unable to use a huge number of apps, this is all I needed; they work completely fine after disabling Glamor. I nearly shed a tear.

Glamor appears to be both semi-abandoned and completely useless on modern hardware. To prevent anyone else from suffering this same fate I have submitted this PR. This seems to be a common problem with Nvidia+Wayland, so if it belongs anywhere, I figure this project is the place.

What is Glamor?
https://www.freedesktop.org/wiki/Software/Glamor/

Issues regarding Glamor/Xwayland
https://gitlab.freedesktop.org/xorg/xserver/-/issues/1317
https://gitlab.freedesktop.org/xorg/xserver/-/issues/1288