### PR TITLE
feat: support for jetbrains ides

### DIFF
--- a/wlroots-env-nvidia.sh
+++ b/wlroots-env-nvidia.sh
@@ -20,3 +20,5 @@ export __GL_VRR_ALLOWED=0
 export __GLX_VENDOR_LIBRARY_NAME=nvidia
 # Xwayland compatibility
 export XWAYLAND_NO_GLAMOR=1
+# JetBrains Idea-based IDEs
+export _JAVA_AWT_WM_NONREPARENTING=1


### PR DESCRIPTION
The JetBrains IDEs have some weird issues with their hacky popup windows that can cause black rendering. flickering and even whole XWayland crashes without this variable set.